### PR TITLE
Add onBlur validation and fix submission validation

### DIFF
--- a/src/components/CheckBox/index.js
+++ b/src/components/CheckBox/index.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import './index.css';
 
-const CheckBox = ({ label, name, handleChange }) => (
+const CheckBox = ({ label, name, handleChange, onBlur }) => (
   <div className="checkbox-group">
     <input 
         type="checkbox"
+        name={ name }
         id={ name }
-        onChange={ ({ target: { checked } }) => handleChange(checked) } />
+        onChange={ ({ target: { checked } }) => handleChange(checked) }
+        onBlur={ ({ target: { checked } }) => onBlur(checked) } />
     <label htmlFor={ name }>{ label }</label>
   </div>
 );

--- a/src/components/InfoForm/index.js
+++ b/src/components/InfoForm/index.js
@@ -20,6 +20,7 @@ class InfoForm extends React.Component {
     this.state = this.initialState;
 
     this.handleChange = this.handleChange.bind(this);
+    this.onBlur = this.onBlur.bind(this);
     this.submit = this.submit.bind(this);
   }
 
@@ -48,9 +49,20 @@ class InfoForm extends React.Component {
     return { valid: true,  message: '' };
   }
 
-  handleChange(name, fieldIndex) {
+  onBlur(name, fieldIndex) {
     return value => {
       let { valid, message } = this.validate(value, fieldIndex);
+      this.setState({
+        validation: { ...this.state.validation, [name]: { valid, message } },
+      });
+    }
+  }
+
+  handleChange(name, fieldIndex) {
+    return value => {
+      let { valid, message } = !this.state.validation[name].valid
+          ? this.validate(value, fieldIndex)
+          : this.state.validation[name];
       this.setState({
         response: { ...this.state.response, [name]: value },
         validation: { ...this.state.validation, [name]: { valid, message } },
@@ -59,9 +71,9 @@ class InfoForm extends React.Component {
   }
 
   submit() {
-    const validation = Object.keys(this.state.validation).reduce((acc, fieldKey) => {
+    const validation = this.props.fields.reduce((acc, { name: fieldKey }, fieldIndex) => {
       if (fieldKey !== 'valid') {
-        acc[fieldKey] = this.checkEmpty(this.state.response[fieldKey]);
+        acc[fieldKey] = this.validate(this.state.response[fieldKey], fieldIndex);
         if (!acc[fieldKey].valid) { acc.valid = false }
       }
       return acc;
@@ -85,7 +97,8 @@ class InfoForm extends React.Component {
                     name={ name }
                     placeholder={ placeholder }
                     value={ this.state.response[name] }
-                    handleChange={ this.handleChange(name, fieldIndex) } />
+                    handleChange={ this.handleChange(name, fieldIndex) }
+                    onBlur={ this.onBlur(name, fieldIndex) } />
               );
               break;
             }
@@ -95,7 +108,8 @@ class InfoForm extends React.Component {
                     name={ name }
                     options={ options }
                     value={ this.state.response[name] }
-                    handleChange={ this.handleChange(name, fieldIndex) } />
+                    handleChange={ this.handleChange(name, fieldIndex) }
+                    onBlur={ this.onBlur(name, fieldIndex) } />
               );
               break;
             }
@@ -105,7 +119,8 @@ class InfoForm extends React.Component {
                     label={ label }
                     name={ name }
                     value={ this.state.response[name] }
-                    handleChange={ this.handleChange(name, fieldIndex) } />
+                    handleChange={ this.handleChange(name, fieldIndex) }
+                    onBlur={ this.onBlur(name, fieldIndex) } />
               );
               break;
             }

--- a/src/components/NumericInput/index.js
+++ b/src/components/NumericInput/index.js
@@ -1,12 +1,14 @@
 import React from 'react';
 
-const NumericInput = ({ name, placeholder, value, handleChange }) => (
+const NumericInput = ({ name, placeholder, value, handleChange, onBlur }) => (
   <input 
       type="number"
+      name={ name }
       id={ name }
       placeholder={ placeholder }
       value={ value }
-      onChange={ ({ target: { value } }) => handleChange(value) } />
+      onChange={ ({ target: { value } }) => handleChange(value) }
+      onBlur={ ({ target: { value } }) => onBlur(value) } />
 );
 
 export default NumericInput;

--- a/src/components/OptionGroup/index.js
+++ b/src/components/OptionGroup/index.js
@@ -1,15 +1,20 @@
 import React from 'react';
 import './index.css';
 
-const OptionGroup = ({ options, value, handleChange }) => (
+const OptionGroup = ({ name, options, value, handleChange, onBlur }) => (
   <div className="option-group">
     {options.map(option => 
       <input
+          name={ name }
           key={ option }
           type="button"
-          className={value === option ? 'selected' : ''}
+          className={ value === option ? 'selected' : '' }
           value={ option }
-          onClick={ () => handleChange(option) } />
+          onClick={ () => handleChange(option) }
+          onBlur={ ({ relatedTarget }) => 
+              relatedTarget && relatedTarget.name &&
+              relatedTarget.name !== name && onBlur(value)
+          } />
     )}
   </div>
 );


### PR DESCRIPTION
Due to a bug submission validation previously only checked for empty fields. Now it runs validation function.

Validation on valid field now occurs on blur event instead of on change event but validation on invalid field still occurs on change event. It is quick to indicate the invalid value is now valid but it will allow you to complete your response and move on before telling you your valid response is now invalid.